### PR TITLE
Run all tests in a tmp dir

### DIFF
--- a/bin/testmachinepack-mocha.js
+++ b/bin/testmachinepack-mocha.js
@@ -9,7 +9,7 @@ var Mocha = require('mocha');
 //from within the projects package.json
 var timeoutPos = process.argv.indexOf('-t');
 var timeout = 10000;
-if (timeoutPos > -1) {
+if (timeoutPos > -1 && process.argv[timeoutPos + 1] !== undefined) {
   timeout = process.argv[timeoutPos + 1];
 }
 

--- a/bin/testmachinepack-mocha.js
+++ b/bin/testmachinepack-mocha.js
@@ -5,8 +5,16 @@
 // (based on example @ https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically)
 var path = require('path');
 var Mocha = require('mocha');
+//allow the customization of the timeout by passing a -t flag
+//from within the projects package.json
+var timeoutPos = process.argv.indexOf('-t');
+var timeout = 10000;
+if (timeoutPos > -1) {
+  timeout = process.argv[timeoutPos + 1];
+}
+
 var mocha = new Mocha({
-  timeout: 10000
+  timeout: timeout
 });
 mocha.addFile(path.resolve(__dirname,'../mocha-test.js'));
 mocha.run(function(failures){

--- a/index.js
+++ b/index.js
@@ -4,13 +4,18 @@
 
 var _ = require('lodash');
 var RawMachinepackTestRunner = require('test-machinepack').rawTestRunner;
+var tmp = require('tmp-sync');
+var fs = require('fs-extra');
+
+var root = process.cwd();
+var tmproot = path.join(root, 'tmp');
 
 
 // Customize generic test driver for mocha
 module.exports = function mochaDriver(pathToMachinepackDir) {
 
   // Use cwd as our path unless overridden by the arg above
-  pathToMachinepackDir = pathToMachinepackDir || process.cwd();
+  pathToMachinepackDir = pathToMachinepackDir || root;
 
   RawMachinepackTestRunner(pathToMachinepackDir,function beforeRunningAnyTests(opts, done){
     // e.g. set mocha.opts based on generic `opts` provided
@@ -18,6 +23,18 @@ module.exports = function mochaDriver(pathToMachinepackDir) {
     done();
   }, function eachMachineSuite(machineIdentity, runTests){
     describe('`'+machineIdentity+'` machine', function (){
+      var tmpdir;
+
+      before(function(){
+        tmpdir = tmp.in(tmproot);
+        process.chdir(tmpdir);
+      });
+
+      after(function(){
+        process.chdir(root);
+        fs.remove(tmproot);
+      });
+
       runTests(function onTest(testCase, nextTestCase){
         var jsonInputVals;
         try {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function mochaDriver(pathToMachinepackDir) {
 
       after(function(){
         process.chdir(root);
-        fs.remove(tmproot);
+        fs.removeSync(tmproot);
       });
 
       runTests(function onTest(testCase, nextTestCase){

--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
  */
 
 var _ = require('lodash');
-var RawMachinepackTestRunner = require('test-machinepack').rawTestRunner;
+var path = require('path')
 var tmp = require('tmp-sync');
 var fs = require('fs-extra');
+var RawMachinepackTestRunner = require('test-machinepack').rawTestRunner;
 
 var root = process.cwd();
 var tmproot = path.join(root, 'tmp');

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "testmachinepack-mocha": "./bin/testmachinepack-mocha.js"
   },
   "dependencies": {
-    "lodash": "^3.1.0",
     "async": "^0.9.0",
-    "test-machinepack": "^0.1.7",
-    "mocha": "^2.1.0"
+    "fs-extra": "^0.16.3",
+    "lodash": "^3.1.0",
+    "mocha": "^2.1.0",
+    "test-machinepack": "^0.1.8",
+    "tmp-sync": "^1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some tests  change the state of the current folder, for example: https://github.com/mikermcneil/machinepack-npm/pull/2

For example, testing the `--save-dev` flag adds a package to the `node_modules` folder but also adds the package to the `package.json`. Running every test in a tmp folder resolves this. But I also think that could be useful for other project-tests that generate files, etc. Also in theory that should not have any downsides for other projects (which in practice can of course be different for certain edge-cases, when working with the filesystem).

So this PR creates a tmp folder in the `before` hook and removes it in the `after` hook.

Let me know if you think that is a good idea.

Also I added the possibility to customize the timeout, since I constantly got a timeout for one of the tests.

You can now set this via

``` js
  "scripts": {
    "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js -t 12000"
  }
```

Default is still 10 seconds when nothing is given.
