### PR TITLE
Add optional singleMachineToTest

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,15 +11,14 @@ var RawMachinepackTestRunner = require('test-machinepack').rawTestRunner;
 var root = process.cwd();
 var tmproot = path.join(root, 'tmp');
 
-
 // Customize generic test driver for mocha
-module.exports = function mochaDriver(pathToMachinepackDir) {
+module.exports = function mochaDriver(pathToMachinepackDir, singleMachineToTest) {
 
   // Use cwd as our path unless overridden by the arg above
   pathToMachinepackDir = pathToMachinepackDir || root;
 
   var opts = {};
-  RawMachinepackTestRunner(pathToMachinepackDir,function beforeRunningAnyTests(_opts, done){
+  RawMachinepackTestRunner(pathToMachinepackDir, singleMachineToTest, function beforeRunningAnyTests(_opts, done){
     // Expose provided options via closure for use throughout this module.
     opts = _opts || {};
 

--- a/mocha-test.js
+++ b/mocha-test.js
@@ -1,3 +1,4 @@
 // Run tests
 // (this file should be invoked with mocha-- see bin/testmachinepack-mocha)
-require('./')();
+var singleMachineToTest = process.argv[2];
+require('./')(null, singleMachineToTest);


### PR DESCRIPTION
Combined with [this PR on test-machinepack](https://github.com/node-machine/test-machinepack/pull/3) allows you to run `npm test machine-name` to test a single machine.

Not very graceful. Using this PR as an example/suggestion.
